### PR TITLE
🐛 updateMetaFromResponse: mark param as nullable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "acb-studio/kirby-cloudinary-sync",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "kirby-plugin",
   "description": "Kirby -> Cloudinary media sync plugin",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -213,7 +213,7 @@ class ACBCloudinarySync
         return $url;
     }
 
-    static function updateMetaFromResponse(File $file, ApiResponse $response = null)
+    static function updateMetaFromResponse(File $file, ?ApiResponse $response = null)
     {
         $file->update([
             'cloudinary_public_id' => $response['public_id'] ?? null,


### PR DESCRIPTION
fixes PHP error with latest versions