### PR TITLE
🐛 fix broken url when resizing image with existing extension delimiter in file name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "acb-studio/kirby-cloudinary-sync",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "kirby-plugin",
   "description": "Kirby -> Cloudinary media sync plugin",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -55,7 +55,7 @@ class ACBCloudinaryAssetVersion extends FileVersion
         }
 
         $image = new CloudinaryImage(new AssetDescriptor(
-            $file->cloudinary_public_id()->value(),
+            $file->cloudinary_public_id()->value() . '.' . $file->extension(),
             AssetType::IMAGE
         ), []);
 
@@ -88,7 +88,6 @@ class ACBCloudinaryAssetVersion extends FileVersion
         ));
 
         $image->version($version);
-        $image->extension($file->extension());
         $transformedPath = $image->toUrl()->getPath();
 
         if ($crop) {


### PR DESCRIPTION
For file names like `screenshot-2025-11-22-at-10.05.21.png`, the plugin was swapping out `21` with `png`